### PR TITLE
Collection diff struct basic

### DIFF
--- a/pkg/assertions/map_diff_test.go
+++ b/pkg/assertions/map_diff_test.go
@@ -1,6 +1,7 @@
 package assertions
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -97,4 +98,17 @@ func TestMapDiff(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExampleAssert_MapDiff demonstrates proper usage of map diff assertion
+func ExampleAssert_MapDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two maps are identical
+	got := map[string]int{"alice": 30, "bob": 25}
+	want := map[string]int{"alice": 30, "bob": 25}
+	assert.MapDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
 }

--- a/pkg/assertions/slice_diff_generic_test.go
+++ b/pkg/assertions/slice_diff_generic_test.go
@@ -1,6 +1,7 @@
 package assertions
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -97,4 +98,17 @@ func TestSliceDiffGeneric(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExampleAssert_SliceDiffGeneric demonstrates proper usage of generic slice diff assertion
+func ExampleAssert_SliceDiffGeneric() {
+	assert := New(&testing.T{})
+
+	// Test that two string slices are identical
+	got := []string{"apple", "banana", "cherry"}
+	want := []string{"apple", "banana", "cherry"}
+	assert.SliceDiffGeneric(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
 }

--- a/pkg/assertions/slice_diff_test.go
+++ b/pkg/assertions/slice_diff_test.go
@@ -1,6 +1,7 @@
 package assertions
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -74,4 +75,17 @@ func TestSliceDiffBasic(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExampleAssert_SliceDiff demonstrates proper usage of basic slice diff assertion
+func ExampleAssert_SliceDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two integer slices are identical
+	got := []int{1, 2, 3}
+	want := []int{1, 2, 3}
+	assert.SliceDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
 }

--- a/pkg/assertions/struct_diff_test.go
+++ b/pkg/assertions/struct_diff_test.go
@@ -1,0 +1,131 @@
+package assertions
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Test structs for struct diff testing
+type Person struct {
+	Name string
+	Age  int
+	City string
+}
+
+type Product struct {
+	ID    int
+	Name  string
+	Price float64
+	Tags  []string
+}
+
+// TestStructDiff tests struct diff functionality with behaviour-focused testing
+func TestStructDiff(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupAndAssert      func(assert *Assert)
+		expectErrorContains []string
+		shouldPass          bool
+	}{
+		{
+			name: "identical structs should pass",
+			setupAndAssert: func(assert *Assert) {
+				got := Person{Name: "Alice", Age: 30, City: "London"}
+				want := Person{Name: "Alice", Age: 30, City: "London"}
+				assert.StructDiff(got, want)
+			},
+			shouldPass: true,
+		},
+		{
+			name: "different field values should fail with field details",
+			setupAndAssert: func(assert *Assert) {
+				got := Person{Name: "Alice", Age: 25, City: "London"}
+				want := Person{Name: "Alice", Age: 30, City: "London"}
+				assert.StructDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Age\"",
+				"got: 25",
+				"want: 30",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "multiple field differences should show first difference",
+			setupAndAssert: func(assert *Assert) {
+				got := Person{Name: "Bob", Age: 25, City: "Manchester"}
+				want := Person{Name: "Alice", Age: 30, City: "London"}
+				assert.StructDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Name\"",
+				"got: Bob",
+				"want: Alice",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "complex struct with slice field differences",
+			setupAndAssert: func(assert *Assert) {
+				got := Product{ID: 1, Name: "Widget", Price: 9.99, Tags: []string{"small", "red"}}
+				want := Product{ID: 1, Name: "Widget", Price: 9.99, Tags: []string{"small", "blue"}}
+				assert.StructDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Tags\"",
+			},
+			shouldPass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a dummy testing.T that captures failures
+			dummyT := &capturingT{}
+			assert := New(dummyT)
+
+			// Execute the struct diff assertion
+			tt.setupAndAssert(assert)
+
+			errorMsg := assert.Error()
+
+			if tt.shouldPass {
+				if errorMsg != "" {
+					t.Errorf("Expected assertion to pass but got error: %s", errorMsg)
+				}
+			} else {
+				if errorMsg == "" {
+					t.Fatalf("Expected error message but got none")
+				}
+
+				for _, expected := range tt.expectErrorContains {
+					if !strings.Contains(errorMsg, expected) {
+						t.Errorf("Error message missing expected content %q\nFull error message:\n%s", expected, errorMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ExampleAssert_StructDiff demonstrates proper usage of struct diff assertion
+func ExampleAssert_StructDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two structs are identical
+	type User struct {
+		Name string
+		Age  int
+	}
+
+	got := User{Name: "Alice", Age: 30}
+	want := User{Name: "Alice", Age: 30}
+	assert.StructDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
+}


### PR DESCRIPTION
## Summary
- Add `StructDiff` method for detailed struct field comparison
- Complete documentation with missing Example functions for all Collection Diff Helpers
- Comprehensive test coverage following TDD Red-Green-Refactor methodology

## Changes
**New StructDiff functionality:**
- `StructDiff(got, want any)` method with field-level error reporting
- Type-safe struct validation and unexported field handling
- Detailed error messages showing specific field differences

**Complete documentation:**
- `ExampleAssert_StructDiff` - struct comparison usage
- `ExampleAssert_SliceDiff` - integer slice comparison usage
- `ExampleAssert_SliceDiffGeneric` - generic slice comparison usage
- `ExampleAssert_MapDiff` - map comparison usage

## Collection Diff Helpers Status
- ✅ `SliceDiff` - Integer slice comparison with enhanced errors
- ✅ `SliceDiffGeneric` - Any slice type with detailed reporting
- ✅ `MapDiff` - Map comparison showing missing/extra keys and value differences
- ✅ `StructDiff` - Struct field comparison with specific field error reporting
  
## Related Issues
- Completes major portion of #53 (Collection Diff Helpers)
- All three core collection types now have enhanced diff functionality
- Documentation complete for `go doc` integration