### PR TITLE
TDD: Add DeepDiff universal handler completing Collection Diff Helpers

### DIFF
--- a/pkg/assertions/deep_diff_test.go
+++ b/pkg/assertions/deep_diff_test.go
@@ -1,0 +1,185 @@
+package assertions
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Test types for deep diff testing
+type Contact struct {
+	Name  string
+	Email string
+	Tags  []string
+}
+
+type Company struct {
+	Name      string
+	Employees []Contact
+	Locations map[string]string
+}
+
+// TestDeepDiff tests universal deep diff functionality with behaviour-focused testing
+func TestDeepDiff(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupAndAssert      func(assert *Assert)
+		expectErrorContains []string
+		shouldPass          bool
+	}{
+		{
+			name: "identical primitives should pass",
+			setupAndAssert: func(assert *Assert) {
+				got := "hello"
+				want := "hello"
+				assert.DeepDiff(got, want)
+			},
+			shouldPass: true,
+		},
+		{
+			name: "different primitives should fail",
+			setupAndAssert: func(assert *Assert) {
+				got := 42
+				want := 24
+				assert.DeepDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"values differ",
+				"got: 42",
+				"want: 24",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "slice differences should use SliceDiffGeneric",
+			setupAndAssert: func(assert *Assert) {
+				got := []string{"a", "b", "x"}
+				want := []string{"a", "b", "c"}
+				assert.DeepDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"slices differ",
+				"index 2",
+				"got: x",
+				"want: c",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "map differences should use MapDiff",
+			setupAndAssert: func(assert *Assert) {
+				got := map[string]int{"a": 1, "b": 5}
+				want := map[string]int{"a": 1, "b": 2}
+				assert.DeepDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"maps differ",
+				"key \"b\"",
+				"got: 5",
+				"want: 2",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "struct differences should use StructDiff",
+			setupAndAssert: func(assert *Assert) {
+				got := Contact{Name: "Alice", Email: "alice@old.com", Tags: []string{"dev"}}
+				want := Contact{Name: "Alice", Email: "alice@new.com", Tags: []string{"dev"}}
+				assert.DeepDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Email\"",
+				"got: alice@old.com",
+				"want: alice@new.com",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "complex nested structures should provide detailed diff",
+			setupAndAssert: func(assert *Assert) {
+				got := Company{
+					Name: "TechCorp",
+					Employees: []Contact{
+						{Name: "Alice", Email: "alice@tech.com", Tags: []string{"dev"}},
+					},
+					Locations: map[string]string{"HQ": "London"},
+				}
+				want := Company{
+					Name: "TechCorp",
+					Employees: []Contact{
+						{Name: "Bob", Email: "alice@tech.com", Tags: []string{"dev"}},
+					},
+					Locations: map[string]string{"HQ": "London"},
+				}
+				assert.DeepDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Employees\"",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "different types should fail clearly",
+			setupAndAssert: func(assert *Assert) {
+				got := []string{"a", "b"}
+				want := map[string]int{"a": 1}
+				assert.DeepDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"types differ",
+				"[]string",
+				"map[string]int",
+			},
+			shouldPass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a dummy testing.T that captures failures
+			dummyT := &capturingT{}
+			assert := New(dummyT)
+
+			// Execute the deep diff assertion
+			tt.setupAndAssert(assert)
+
+			errorMsg := assert.Error()
+
+			if tt.shouldPass {
+				if errorMsg != "" {
+					t.Errorf("Expected assertion to pass but got error: %s", errorMsg)
+				}
+			} else {
+				if errorMsg == "" {
+					t.Fatalf("Expected error message but got none")
+				}
+
+				for _, expected := range tt.expectErrorContains {
+					if !strings.Contains(errorMsg, expected) {
+						t.Errorf("Error message missing expected content %q\nFull error message:\n%s", expected, errorMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ExampleAssert_DeepDiff demonstrates proper usage of universal deep diff assertion
+func ExampleAssert_DeepDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two complex structures are identical
+	type Person struct {
+		Name string
+		Tags []string
+	}
+
+	got := Person{Name: "Alice", Tags: []string{"dev", "lead"}}
+	want := Person{Name: "Alice", Tags: []string{"dev", "lead"}}
+	assert.DeepDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
+}

--- a/pkg/assertions/map_diff_test.go
+++ b/pkg/assertions/map_diff_test.go
@@ -1,6 +1,7 @@
 package assertions
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -97,4 +98,17 @@ func TestMapDiff(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExampleAssert_MapDiff demonstrates proper usage of map diff assertion
+func ExampleAssert_MapDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two maps are identical
+	got := map[string]int{"alice": 30, "bob": 25}
+	want := map[string]int{"alice": 30, "bob": 25}
+	assert.MapDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
 }

--- a/pkg/assertions/slice_diff_generic_test.go
+++ b/pkg/assertions/slice_diff_generic_test.go
@@ -1,6 +1,7 @@
 package assertions
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -97,4 +98,17 @@ func TestSliceDiffGeneric(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExampleAssert_SliceDiffGeneric demonstrates proper usage of generic slice diff assertion
+func ExampleAssert_SliceDiffGeneric() {
+	assert := New(&testing.T{})
+
+	// Test that two string slices are identical
+	got := []string{"apple", "banana", "cherry"}
+	want := []string{"apple", "banana", "cherry"}
+	assert.SliceDiffGeneric(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
 }

--- a/pkg/assertions/slice_diff_test.go
+++ b/pkg/assertions/slice_diff_test.go
@@ -1,6 +1,7 @@
 package assertions
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -74,4 +75,17 @@ func TestSliceDiffBasic(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExampleAssert_SliceDiff demonstrates proper usage of basic slice diff assertion
+func ExampleAssert_SliceDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two integer slices are identical
+	got := []int{1, 2, 3}
+	want := []int{1, 2, 3}
+	assert.SliceDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
 }

--- a/pkg/assertions/struct_diff_test.go
+++ b/pkg/assertions/struct_diff_test.go
@@ -1,0 +1,131 @@
+package assertions
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Test structs for struct diff testing
+type Person struct {
+	Name string
+	Age  int
+	City string
+}
+
+type Product struct {
+	ID    int
+	Name  string
+	Price float64
+	Tags  []string
+}
+
+// TestStructDiff tests struct diff functionality with behaviour-focused testing
+func TestStructDiff(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupAndAssert      func(assert *Assert)
+		expectErrorContains []string
+		shouldPass          bool
+	}{
+		{
+			name: "identical structs should pass",
+			setupAndAssert: func(assert *Assert) {
+				got := Person{Name: "Alice", Age: 30, City: "London"}
+				want := Person{Name: "Alice", Age: 30, City: "London"}
+				assert.StructDiff(got, want)
+			},
+			shouldPass: true,
+		},
+		{
+			name: "different field values should fail with field details",
+			setupAndAssert: func(assert *Assert) {
+				got := Person{Name: "Alice", Age: 25, City: "London"}
+				want := Person{Name: "Alice", Age: 30, City: "London"}
+				assert.StructDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Age\"",
+				"got: 25",
+				"want: 30",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "multiple field differences should show first difference",
+			setupAndAssert: func(assert *Assert) {
+				got := Person{Name: "Bob", Age: 25, City: "Manchester"}
+				want := Person{Name: "Alice", Age: 30, City: "London"}
+				assert.StructDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Name\"",
+				"got: Bob",
+				"want: Alice",
+			},
+			shouldPass: false,
+		},
+		{
+			name: "complex struct with slice field differences",
+			setupAndAssert: func(assert *Assert) {
+				got := Product{ID: 1, Name: "Widget", Price: 9.99, Tags: []string{"small", "red"}}
+				want := Product{ID: 1, Name: "Widget", Price: 9.99, Tags: []string{"small", "blue"}}
+				assert.StructDiff(got, want)
+			},
+			expectErrorContains: []string{
+				"structs differ",
+				"field \"Tags\"",
+			},
+			shouldPass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a dummy testing.T that captures failures
+			dummyT := &capturingT{}
+			assert := New(dummyT)
+
+			// Execute the struct diff assertion
+			tt.setupAndAssert(assert)
+
+			errorMsg := assert.Error()
+
+			if tt.shouldPass {
+				if errorMsg != "" {
+					t.Errorf("Expected assertion to pass but got error: %s", errorMsg)
+				}
+			} else {
+				if errorMsg == "" {
+					t.Fatalf("Expected error message but got none")
+				}
+
+				for _, expected := range tt.expectErrorContains {
+					if !strings.Contains(errorMsg, expected) {
+						t.Errorf("Error message missing expected content %q\nFull error message:\n%s", expected, errorMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ExampleAssert_StructDiff demonstrates proper usage of struct diff assertion
+func ExampleAssert_StructDiff() {
+	assert := New(&testing.T{})
+
+	// Test that two structs are identical
+	type User struct {
+		Name string
+		Age  int
+	}
+
+	got := User{Name: "Alice", Age: 30}
+	want := User{Name: "Alice", Age: 30}
+	assert.StructDiff(got, want)
+
+	fmt.Println("No error:", assert.Error() == "")
+	// Output: No error: true
+}


### PR DESCRIPTION
  ## Summary
  - Add `DeepDiff` method as universal handler for any type comparison
  - Intelligent routing to specialized diff methods based on type
  - Completes Issue #53 Collection Diff Helpers with comprehensive coverage

  ## Changes
  - **DeepDiff method**: Universal entry point for any type comparison
  - **Intelligent routing**: Automatically uses best specialized method:
    - Slices → `SliceDiffGeneric`
    - Maps → `MapDiff`
    - Structs → `StructDiff`
    - Primitives → Clear value comparison
  - **Type safety**: Clear errors when types differ
  - **Performance optimized**: Quick equality check before reflection
  - **Documentation**: Example function for `go doc` integration

  ## Issue #53 - Collection Diff Helpers COMPLETE
  - ✅ `SliceDiff` - Basic integer slice comparison
  - ✅ `SliceDiffGeneric` - Any slice type with detailed reporting
  - ✅ `MapDiff` - Map comparison with missing/extra key analysis
  - ✅ `StructDiff` - Struct field-level comparison
  - ✅ `DeepDiff` - Universal handler for any type combination