### PR TITLE
Implement Shared Failure State for Proper Fail-Fast Chaining

### DIFF
--- a/pkg/assertions/assertions.go
+++ b/pkg/assertions/assertions.go
@@ -96,7 +96,7 @@ type Assert struct {
 func New(t interface{}) *Assert {
 	// Initialize shared failure state - will escape to heap for pointer sharing
 	var failed int32 = 0
-	
+
 	return &Assert{
 		t:          t,
 		failed:     &failed,        // Pointer to shared atomic int32

--- a/pkg/assertions/assertions.go
+++ b/pkg/assertions/assertions.go
@@ -92,8 +92,11 @@ type Assert struct {
 }
 
 // New creates a new Assert instance with the given testing context.
+// Note: Allocates shared failure state on heap for thread-safe chaining across instances.
 func New(t interface{}) *Assert {
-	failed := int32(0) // Initialize shared failure state
+	// Initialize shared failure state - will escape to heap for pointer sharing
+	var failed int32 = 0
+	
 	return &Assert{
 		t:          t,
 		failed:     &failed,        // Pointer to shared atomic int32

--- a/pkg/assertions/assertions.go
+++ b/pkg/assertions/assertions.go
@@ -87,27 +87,29 @@ const (
 type Assert struct {
 	t          interface{}
 	errorMsg   string
-	failed     int32      // atomic: 0=not failed, 1=failed (for fail-fast chaining)
+	failed     *int32     // atomic: pointer to shared failure state (0=not failed, 1=failed)
 	diffFormat DiffFormat // Preferred format for multi-line string diffs
 }
 
 // New creates a new Assert instance with the given testing context.
 func New(t interface{}) *Assert {
+	failed := int32(0) // Initialize shared failure state
 	return &Assert{
 		t:          t,
+		failed:     &failed,        // Pointer to shared atomic int32
 		diffFormat: DiffFormatAuto, // Default to automatic format selection
 	}
 }
 
 // WithDiffFormat returns a new Assert instance with the specified diff format preference.
 // This follows GoWise principles of immutable configuration.
-// NOTE: Creates an independent assertion chain with its own failure state.
+// NOTE: Shares failure state with original for proper fail-fast chaining.
 func (a *Assert) WithDiffFormat(format DiffFormat) *Assert {
-	// Create new instance with independent failure state
+	// Share the same atomic failure state pointer for proper chaining
 	newAssert := &Assert{
 		t:          a.t,
 		errorMsg:   a.errorMsg,
-		failed:     a.failed, // Copies the current failure state value
+		failed:     a.failed, // Share the same atomic pointer
 		diffFormat: format,
 	}
 	return newAssert
@@ -116,13 +118,13 @@ func (a *Assert) WithDiffFormat(format DiffFormat) *Assert {
 // shouldSkipDueToFailure checks if we should skip this assertion due to fail-fast
 // Thread-safe for concurrent access.
 func (a *Assert) shouldSkipDueToFailure() bool {
-	return atomic.LoadInt32(&a.failed) != 0
+	return atomic.LoadInt32(a.failed) != 0
 }
 
 // markAsFailed atomically marks this assertion chain as failed
 // Thread-safe for concurrent access.
 func (a *Assert) markAsFailed() bool {
-	return atomic.CompareAndSwapInt32(&a.failed, 0, 1)
+	return atomic.CompareAndSwapInt32(a.failed, 0, 1)
 }
 
 // reportErrorConsistent provides consistent error reporting across all assertion methods
@@ -479,7 +481,7 @@ func (a *Assert) Error() string {
 // HasFailed returns true if any assertion in the chain has failed.
 // This enables fail-fast chaining behaviour.
 func (a *Assert) HasFailed() bool {
-	return atomic.LoadInt32(&a.failed) != 0
+	return atomic.LoadInt32(a.failed) != 0
 }
 
 // Nil asserts that a value is nil.

--- a/pkg/assertions/assertions.go
+++ b/pkg/assertions/assertions.go
@@ -92,7 +92,7 @@ type Assert struct {
 }
 
 // New creates a new Assert instance with the given testing context.
-// Note: Allocates one int32 on heap to enable fail-fast chaining across all WithDiffFormat instances.
+// Note: Allocates one int32 on the heap to enable fail-fast chaining across all chain methods that return new Assert instances sharing the failure state (e.g., WithDiffFormat).
 func New(t interface{}) *Assert {
 	// Initialize shared failure state - will escape to heap for pointer sharing
 	var failed int32

--- a/pkg/assertions/assertions.go
+++ b/pkg/assertions/assertions.go
@@ -92,10 +92,10 @@ type Assert struct {
 }
 
 // New creates a new Assert instance with the given testing context.
-// Note: Allocates shared failure state on heap for thread-safe chaining across instances.
+// Note: Allocates one int32 on heap to enable fail-fast chaining across all WithDiffFormat instances.
 func New(t interface{}) *Assert {
 	// Initialize shared failure state - will escape to heap for pointer sharing
-	var failed int32 = 0
+	var failed int32
 
 	return &Assert{
 		t:          t,


### PR DESCRIPTION
# Summary

  Fixes fluent chaining behavior by implementing shared atomic failure state across all Assert instances, ensuring proper fail-fast semantics when using `WithDiffFormat()` and other
  chain methods.

  ## Problem

  Previously, WithDiffFormat() created independent assertion chains by copying the int32 failure state value. This broke fail-fast chaining expectations:
````
  // Before: Broken behavior
  assert.Equal(a, b).WithDiffFormat(DiffFormatUnified).Equal(c, d)
  // If first Equal failed, second Equal could still execute and report errors
```
 ## Solution

  - Changed failed field: From int32 to *int32 (pointer to shared atomic state)
  - Updated constructor: New() allocates shared failure state that all chain instances reference
  - Fixed WithDiffFormat(): Now shares the same atomic pointer instead of copying values
  - Updated atomic operations: All methods now use pointer-based atomic operations

##  Result

  // After: Proper fail-fast chaining
  assert.Equal(a, b).WithDiffFormat(DiffFormatUnified).Equal(c, d)
  // If first Equal fails, all subsequent methods become no-ops

 ## Key Benefits

  - Consistent API behavior - all chain methods respect shared failure state
  - Thread-safe - atomic operations prevent race conditions
  - Zero dependencies - uses only sync/atomic from stdlib
  - Performance preserved - minimal overhead (one pointer indirection)
  - User expectations met - fluent chaining works as expected

##  Testing

  - All existing tests pass with race detection
  - Manual verification confirms proper failure state sharing
  - Thread safety maintained across concurrent access patterns

  Resolves Copilot AI feedback on broken fail-fast chaining semantics on previous PR.